### PR TITLE
Add province cleanup

### DIFF
--- a/src/covidify/cli.py
+++ b/src/covidify/cli.py
@@ -6,6 +6,7 @@ import covidify
 from covidify.config import SCRIPT
 from covidify.utils.utils import replace_arg_space
 from covidify.list_countries import get_countries
+from covidify.utils.utils import valid_province
 
 USER = getpass.getuser()
 
@@ -53,7 +54,18 @@ def check_country(country, msg):
         return 'Global'
     else:
         country_str = replace_arg_space(country[0])
-        return country_str
+        return "'" + country_str + "'"
+
+def check_province(province, msg):
+
+    if not province:
+        print('%sMESSAGE: %s' % (' '*5, msg))
+        return None
+    else:
+        province_str = province
+        print('Province = %s' % ( province_str))
+
+        return "'" + province_str + "'"
 
 def check_list_flag(flag, msg):
 
@@ -77,7 +89,8 @@ def cli():
 @click.option('--output',  help='Folder to output data and reports [Default: /Users/' + USER + '/Desktop/covidify-output/]')
 @click.option('--source',  help='There are two datasources to choose from, John Hopkins github repo or wikipedia -- options are JHU or wiki respectively [Default: JHU]')
 @click.option('--country', help='Filter reports by a country', multiple=True, type=str)
-def run(output, source, country):
+@click.option('--province', default='NO_PROV', help='Filter reports by a province', type=str)
+def run(output, source, country, province):
     '''
     Generate reports for global cases or refine by country.
     '''
@@ -86,8 +99,9 @@ def run(output, source, country):
     country_str = check_country(country, '\033[1;31m No country specified, defaulting to global cases \033[0;0m')    
     output = check_output_folder(output, country_str, '\033[1;31m No output directory given, defaulting to /Users/' + USER + '/Desktop/ \033[0;0m')
     source = check_source_arg(source, '\033[1;31m No source given, defaulting to John Hopkin CSSE github repo \033[0;0m')
-    
-    os.system(env + SCRIPT + ' ' + env + ' ' + output + ' ' + source + ' ' + country_str)
+    province_str = check_province(province, '\033[1;31m No province given, No default.\033[0;0m')
+
+    os.system(env + SCRIPT + ' ' + env + ' ' + output + ' ' + source + ' ' + country_str + ' ' + province_str )
 
 
 @click.option('--countries', help='List countries that have had confirmed cases.', is_flag=True)

--- a/src/covidify/cli.py
+++ b/src/covidify/cli.py
@@ -89,7 +89,7 @@ def cli():
 @click.option('--output',  help='Folder to output data and reports [Default: /Users/' + USER + '/Desktop/covidify-output/]')
 @click.option('--source',  help='There are two datasources to choose from, John Hopkins github repo or wikipedia -- options are JHU or wiki respectively [Default: JHU]')
 @click.option('--country', help='Filter reports by a country', multiple=True, type=str)
-@click.option('--province', default='NO_PROV', help='Filter reports by a province', type=str)
+@click.option('--province',  help='Filter reports by a province', type=str)
 def run(output, source, country, province):
     '''
     Generate reports for global cases or refine by country.
@@ -101,7 +101,10 @@ def run(output, source, country, province):
     source = check_source_arg(source, '\033[1;31m No source given, defaulting to John Hopkin CSSE github repo \033[0;0m')
     province_str = check_province(province, '\033[1;31m No province given, No default.\033[0;0m')
 
-    os.system(env + SCRIPT + ' ' + env + ' ' + output + ' ' + source + ' ' + country_str + ' ' + province_str )
+    if province_str:
+        os.system(env + SCRIPT + ' ' + env + ' ' + output + ' ' + source + ' ' + country_str + ' ' + province_str )
+    else:
+        os.system(env + SCRIPT + ' ' + env + ' ' + output + ' ' + source + ' ' + country_str)
 
 
 @click.option('--countries', help='List countries that have had confirmed cases.', is_flag=True)

--- a/src/covidify/data_prep.py
+++ b/src/covidify/data_prep.py
@@ -9,6 +9,7 @@ Options:
     --output_folder=OUT   Output folder for the data and reports to be saved.
     --source=SRC          Datasource for where the data will be downloaded from.
     --country=CNT         Arg for filtering by a specific country
+    --province=PRV        Arg for filtering by a specific province or state
 """
 from __future__ import print_function
 import os
@@ -22,12 +23,14 @@ from datetime import datetime, date, time
 from covidify.sources import github, wiki
 from covidify.config import REPO, TMP_FOLDER, TMP_GIT, DATA
 from covidify.utils.utils import replace_arg_score
+from covidify.utils.utils import valid_province
 
 
 args = docopt.docopt(__doc__)
 out = args['--output_folder']
 country = args['--country']
 source = args['--source']
+province = args['--province']
 
 
 ############ DATA SELECTION ############
@@ -96,7 +99,20 @@ def check_specified_country(df, country):
         print('... No specific country specified')
         return df
 
+def check_specified_province(df, province):
+
+    if valid_province(province):
+        #Return filtered dataframe
+        print('... filtering data for', province)
+        df = df[df.province == capwords(province)]
+        return df
+    else:
+        print('No specific province specified')
+        return df
+
 df = check_specified_country(df, country)
+if valid_province(province):
+    df = check_specified_province(df, province)
 
 ############ DAILY CASES ############
 

--- a/src/covidify/data_visualization.py
+++ b/src/covidify/data_visualization.py
@@ -114,7 +114,7 @@ def create_bar(tmp_df, col, rgb, country, province):
     fig = ax.get_figure()
     fig.savefig(os.path.join(image_dir, create_save_file(col, country, 'bar', province)))
 
-def create_stacked_bar(tmp_df, col1, col2, fig_title, country, ovincepr):
+def create_stacked_bar(tmp_df, col1, col2, fig_title, country, province):
     tmp_df = tmp_df.set_index('date')
     fig, ax = plt.subplots(figsize=(20,10))
     ax.set_title(create_title(fig_title, country, province))

--- a/src/covidify/pipeline.sh
+++ b/src/covidify/pipeline.sh
@@ -10,6 +10,7 @@ ENV=$1
 OUT_FDR=$2
 SOURCE=$3
 COUNTRY=$4
+PROVINCE=$5
 
 set -e
 
@@ -20,12 +21,13 @@ echo "... ENV: $ENV"
 echo "... OUTPUT FOLDER: $OUT_FDR"
 echo "... DATA SOURCE: $SOURCE"
 echo "... COUNTRIES: $COUNTRY"
+echo "... PROVINCE: $PROVINCE"
 
 banner "Data Extraction"
-python $ENV/data_prep.py --output_folder $OUT_FDR --source $SOURCE --country $COUNTRY
+python $ENV/data_prep.py --output_folder $OUT_FDR --source $SOURCE --country "$COUNTRY" --province "$PROVINCE"
 
 banner "Data Visualization"
-python $ENV/data_visualization.py --output_folder $OUT_FDR --country $COUNTRY
+python $ENV/data_visualization.py --output_folder $OUT_FDR --country "$COUNTRY" --province "$PROVINCE"
 
 banner "Complete!"
 echo "* Results in: $OUT_FDR"

--- a/src/covidify/utils/utils.py
+++ b/src/covidify/utils/utils.py
@@ -14,3 +14,6 @@ def replace_arg_space(country_str):
 
 def replace_arg_score(country_str):
     return country_str.replace('_', ' ')
+
+def valid_province(province):
+	return (province and province != 'NO_PROV')


### PR DESCRIPTION
I made "province" more optional with no defaults.  Perhaps more controversial was my choice to just keep a list of generated images for each run of 'covidify'.   I found that using 'glob' and searching the 'image_dir' resulted in old images being added to  the generated report after multiple runs.